### PR TITLE
expect plots to have the same length as `ggplot()`

### DIFF
--- a/tests/testthat/test_plot_breathtestfit.R
+++ b/tests/testthat/test_plot_breathtestfit.R
@@ -8,7 +8,7 @@ test_that("Plot layers match expectations",{
   expect_s3_class(p, "ggplot")
   expect_gt(max(layer_data(p)$y), 25)
   expect_equal(nlayers(p), 4)   
-  expect_equal(length(p), 9)   
+  expect_equal(length(p), length(ggplot()))   
   expect_equal(nlevels(layer_data(p)$PANEL), 10)
 })
 
@@ -40,7 +40,7 @@ test_that("Plot multiple groups with repeats",{
   p = plot(x)
   expect_s3_class(p, "ggplot")
   expect_equal(nlayers(p), 4)   
-  expect_equal(length(p), 9)   
+  expect_equal(length(p), length(ggplot()))   
   expect_equal(nlevels(layer_data(p)$PANEL), 6)
 })
 
@@ -62,7 +62,7 @@ test_that("Plot multiple groups without repeats",{
   p = plot(x)
   expect_s3_class(p, "ggplot")
   expect_equal(nlayers(p), 4)   
-  expect_equal(length(p), 9)   
+  expect_equal(length(p), length(ggplot()))   
   expect_equal(nlevels(layer_data(p)$PANEL), 15)
 })
 
@@ -78,7 +78,7 @@ test_that("Plot multiple groups data only (no fit)",{
   p = plot(x) # Plots raw data only
   expect_s3_class(p, "ggplot")
   expect_equal(nlayers(p), 1)   
-  expect_equal(length(p), 9)   
+  expect_equal(length(p), length(ggplot()))   
   expect_equal(nlevels(layer_data(p)$PANEL), 6)
 })
 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break breathtestcore.

This PR updates some tests that expected that the result of `ggplot()` has length 9, which is no longer true in the release candidate. The expectation has been updated to match the result of `ggplot()`.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help breathtestcore get out a fix if necessary.