### PR TITLE
Fix for upcoming stringr 1.6.0 release

### DIFF
--- a/R/cleanup_data.R
+++ b/R/cleanup_data.R
@@ -231,7 +231,7 @@ cleanup_data.breathtest_data = function(data, ... ){
       id == "0" || 
       id == "" || 
       dot_lgl("use_filename_as_patient_id", ...))
-    id = str_sub(data["file_name"], 1, -5) 
+    id = unname(str_sub(data["file_name"], 1, -5))
   d = cbind(patient_id = id, data$data[,c("minute", "pdr")])
   cleanup_data(d, ...)    
 }


### PR DESCRIPTION
`str_sub()` now preserves names which was causing `data.frame()` (via `cbind()`) to generate a warning.